### PR TITLE
Protein Inference

### DIFF
--- a/modules/PG_ProteinInference/protein_inference.ipynb
+++ b/modules/PG_ProteinInference/protein_inference.ipynb
@@ -2,13 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
     "\n",
-    "import pandas as pd\n",
     "import argparse\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
     "\n",
     "def process_metamorpheus_file(filename):\n",
     "    \"\"\"\n",
@@ -53,12 +55,7 @@
     "        best_proteins = list(subsizes[subsizes['size'] == max_subsize][protein_column])\n",
     "    return best_proteins[0]\n",
     "\n",
-    "def rescue_indistinguishable(inferred, dropped):\n",
-    "    \"\"\"\n",
-    "    If a dropped protein has the exact match of peptides to an inferred protein then that protein is\n",
-    "    added into the inferred graph\n",
-    "    \"\"\"\n",
-    "    pass\n",
+    "\n",
     "\n",
     "def greedy_inference(original, protein_column = 'Protein Accession', peptide_column = 'Base Sequence'):\n",
     "    \"\"\"\n",
@@ -104,32 +101,30 @@
     "\n",
     "    \"\"\"\n",
     "\n",
-    "    dropped = pd.DataFrame(columns = original.columns)\n",
+    "    # Find peptides that attach to only one protein\n",
+    "    # Add those proteins to inferred proteins bag\n",
+    "    # Remove any peptides that connect to inferred proteins\n",
     "    peptide_sizes = original.groupby(peptide_column).size().reset_index().rename(columns = {0:'size'})\n",
-    "    single = peptide_sizes[peptide_sizes['size'] == 1]\n",
-    "    inferred = original[original[peptide_column].isin(single[peptide_column])]\n",
-    "    inferred = original[original[protein_column].isin(inferred[protein_column])]\n",
-    "    remaining = original[~original[protein_column].isin(inferred[protein_column])]\n",
-    "    inferred = [ inferred ]\n",
+    "    single_peptides = list(peptide_sizes[peptide_sizes['size'] == 1][peptide_column])\n",
+    "    inferred_proteins = list(original[original[peptide_column].isin(single_peptides)][protein_column])\n",
+    "    attached_peptides = list(original[original[protein_column].isin(inferred_proteins)][peptide_column])\n",
+    "    \n",
+    "    remaining = original[~original[peptide_column].isin(attached_peptides)]\n",
     "\n",
     "    while len(remaining) > 0:\n",
+    "        # Greedy select best protein\n",
     "        best_protein = find_best_protein(remaining, original, protein_column)\n",
-    "        matches = remaining[remaining[protein_column] == best_protein]\n",
-    "        tmp_peptides = list(matches[peptide_column])\n",
-    "        inferred.append(matches)\n",
-    "\n",
-    "        is_matched_peptide = remaining[peptide_column].isin(tmp_peptides)\n",
-    "        is_best_protein = remaining[protein_column] == best_protein\n",
-    "        \n",
+    "        inferred_proteins.append(best_protein)\n",
+    "        # Remove peptides that connect to protein from remaining\n",
+    "        attached_peptides = list(remaining[remaining[protein_column] == best_protein][peptide_column])\n",
+    "        is_matched_peptide = remaining[peptide_column].isin(attached_peptides)\n",
     "        remaining = remaining[~is_matched_peptide]\n",
-    "        \n",
-    "    inferred = pd.concat(inferred)\n",
-    "\n",
-    "    inferred_proteins = inferred[protein_column].unique()\n",
+    "    \n",
     "    inferred = original[original[protein_column].isin(inferred_proteins)]\n",
     "    dropped = original[~original[protein_column].isin(inferred_proteins)]\n",
     "    \n",
-    "    return inferred, dropped"
+    "    return inferred, dropped\n",
+    " \n"
    ]
   },
   {
@@ -144,11 +139,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "22.31095004081726\n"
+     ]
+    }
+   ],
    "source": [
-    "o"
+    "import time\n",
+    "start = time.time()\n",
+    "inferred, dropped = greedy_inference(original)\n",
+    "stop = time.time()\n",
+    "print(stop-start)"
    ]
   },
   {
@@ -164,20 +171,18 @@
      ]
     }
    ],
-   "source": [
-    "print(stop-start)"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "Original 71672\nInferred 44071\nDropped 27601\nDropped + Inferred 71672\n"
+      "Original 71672\nInferred 36469\nDropped 35203\nDropped + Inferred 71672\n"
      ]
     }
    ],
@@ -190,65 +195,90 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inferred_set = inferred.groupby('Protein Accession')['Base Sequence'].apply(set)\n",
+    "dropped_set = dropped.groupby('Protein Accession')['Base Sequence'].apply(set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "share_peptides = set()\n",
+    "# share_peptides = []\n",
+    "for d_acc, d_set in dropped_set.iteritems():\n",
+    "    for i_acc, i_set in inferred_set.iteritems():\n",
+    "        if d_set == i_set:\n",
+    "            share_peptides = share_peptides.union([d_acc])\n",
+    "            # share_peptides.append(d_acc)\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "                     File Name  Scan Number  Scan Retention Time  \\\n",
-       "0  120426_Jurkat_highLC_Frac14        19149            140.45874   \n",
-       "1   120426_Jurkat_highLC_Frac9        19892            150.09205   \n",
-       "2  120426_Jurkat_highLC_Frac17        22894            167.51914   \n",
-       "3  120426_Jurkat_highLC_Frac23        14654            119.26644   \n",
-       "4  120426_Jurkat_highLC_Frac20        18563            142.91097   \n",
-       "\n",
-       "   Num Experimental Peaks  Total Ion Current  Precursor Scan Number  \\\n",
-       "0                   186.0       2.620926e+06                  19146   \n",
-       "1                   186.0       1.972297e+05                  19887   \n",
-       "2                   200.0       1.162710e+07                  22893   \n",
-       "3                   200.0       3.137383e+06                  14651   \n",
-       "4                   200.0       1.478450e+06                  18561   \n",
-       "\n",
-       "   Precursor Charge  Precursor MZ  Precursor Mass   Score  ...  \\\n",
-       "0               3.0    1187.22629      3558.65705  39.219  ...   \n",
-       "1               3.0    1221.90388      3662.68981  39.198  ...   \n",
-       "2               4.0     802.65041      3206.57254  39.164  ...   \n",
-       "3               4.0     771.14514      3080.55145  38.355  ...   \n",
-       "4               3.0    1240.64250      3718.90568  37.266  ...   \n",
-       "\n",
-       "   Localized Scores  Improvement Possible Cumulative Target Cumulative Decoy  \\\n",
-       "0                                                         1                0   \n",
-       "1                                                         2                0   \n",
-       "2                                                         3                0   \n",
-       "3                                                         4                0   \n",
-       "4                                                         5                0   \n",
-       "\n",
-       "  QValue  Cumulative Target Notch Cumulative Decoy Notch QValue Notch  \\\n",
-       "0    0.0                        1                      0          0.0   \n",
-       "1    0.0                        2                      0          0.0   \n",
-       "2    0.0                        3                      0          0.0   \n",
-       "3    0.0                        4                      0          0.0   \n",
-       "4    0.0                        5                      0          0.0   \n",
-       "\n",
-       "        PEP  PEP_QValue  \n",
-       "0  0.000028    0.000017  \n",
-       "1  0.000006    0.000003  \n",
-       "2  0.000004    0.000002  \n",
-       "3  0.002980    0.000382  \n",
-       "4  0.000013    0.000008  \n",
-       "\n",
-       "[5 rows x 54 columns]"
-      ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>File Name</th>\n      <th>Scan Number</th>\n      <th>Scan Retention Time</th>\n      <th>Num Experimental Peaks</th>\n      <th>Total Ion Current</th>\n      <th>Precursor Scan Number</th>\n      <th>Precursor Charge</th>\n      <th>Precursor MZ</th>\n      <th>Precursor Mass</th>\n      <th>Score</th>\n      <th>...</th>\n      <th>Localized Scores</th>\n      <th>Improvement Possible</th>\n      <th>Cumulative Target</th>\n      <th>Cumulative Decoy</th>\n      <th>QValue</th>\n      <th>Cumulative Target Notch</th>\n      <th>Cumulative Decoy Notch</th>\n      <th>QValue Notch</th>\n      <th>PEP</th>\n      <th>PEP_QValue</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>120426_Jurkat_highLC_Frac14</td>\n      <td>19149</td>\n      <td>140.45874</td>\n      <td>186.0</td>\n      <td>2.620926e+06</td>\n      <td>19146</td>\n      <td>3.0</td>\n      <td>1187.22629</td>\n      <td>3558.65705</td>\n      <td>39.219</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>1</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>1</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000028</td>\n      <td>0.000017</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>120426_Jurkat_highLC_Frac9</td>\n      <td>19892</td>\n      <td>150.09205</td>\n      <td>186.0</td>\n      <td>1.972297e+05</td>\n      <td>19887</td>\n      <td>3.0</td>\n      <td>1221.90388</td>\n      <td>3662.68981</td>\n      <td>39.198</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>2</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>2</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000006</td>\n      <td>0.000003</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>120426_Jurkat_highLC_Frac17</td>\n      <td>22894</td>\n      <td>167.51914</td>\n      <td>200.0</td>\n      <td>1.162710e+07</td>\n      <td>22893</td>\n      <td>4.0</td>\n      <td>802.65041</td>\n      <td>3206.57254</td>\n      <td>39.164</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>3</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>3</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000004</td>\n      <td>0.000002</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>120426_Jurkat_highLC_Frac23</td>\n      <td>14654</td>\n      <td>119.26644</td>\n      <td>200.0</td>\n      <td>3.137383e+06</td>\n      <td>14651</td>\n      <td>4.0</td>\n      <td>771.14514</td>\n      <td>3080.55145</td>\n      <td>38.355</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>4</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>4</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.002980</td>\n      <td>0.000382</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>120426_Jurkat_highLC_Frac20</td>\n      <td>18563</td>\n      <td>142.91097</td>\n      <td>200.0</td>\n      <td>1.478450e+06</td>\n      <td>18561</td>\n      <td>3.0</td>\n      <td>1240.64250</td>\n      <td>3718.90568</td>\n      <td>37.266</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>5</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>5</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000013</td>\n      <td>0.000008</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 54 columns</p>\n</div>"
+       "13"
+      ]
      },
      "metadata": {},
-     "execution_count": 18
+     "execution_count": 38
     }
    ],
    "source": [
-    "inferred.head()"
+    "len(share_peptides)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "1256"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 36
+    }
+   ],
+   "source": [
+    "len(set(share_peptides))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "{'.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'B', 'P'}"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 39
+    }
+   ],
+   "source": [
+    "share_peptides"
    ]
   },
   {

--- a/modules/PG_ProteinInference/protein_inference.ipynb
+++ b/modules/PG_ProteinInference/protein_inference.ipynb
@@ -2,18 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "idir = '../../../data/inference'\n",
-    "\n",
-    "transcript = pd.read_csv(f\"{idir}/orf_transcript.tsv\", sep = \"\\t\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,62 +11,306 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "UnicodeDecodeError",
-     "evalue": "'utf-8' codec can't decode byte 0xa1 in position 1: invalid start byte",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mUnicodeDecodeError\u001b[0m                        Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-7-6a494e90cc36>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"{idir}/jurkat_mass_spec_frac16.raw\"\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mms\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m         \u001b[0mline\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mms\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreadline\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/opt/conda/lib/python3.7/codecs.py\u001b[0m in \u001b[0;36mdecode\u001b[0;34m(self, input, final)\u001b[0m\n\u001b[1;32m    320\u001b[0m         \u001b[0;31m# decode input (taking the buffer into account)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    321\u001b[0m         \u001b[0mdata\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbuffer\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0minput\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 322\u001b[0;31m         \u001b[0;34m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconsumed\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_buffer_decode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merrors\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfinal\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    323\u001b[0m         \u001b[0;31m# keep undecoded input until the next call\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    324\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbuffer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mconsumed\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mUnicodeDecodeError\u001b[0m: 'utf-8' codec can't decode byte 0xa1 in position 1: invalid start byte"
-     ]
-    }
-   ],
-   "source": [
-    "with open(f\"{idir}/jurkat_mass_spec_frac16.raw\") as ms:\n",
-    "        line = ms.readline()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = ['a','b','c']"
+    "idir = '/Users/bj8th/Documents/Lab-for-Proteoform-Systems-Biology/data/peptides/AllPeptides_PacBio.psmtsv'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
-    "b = '\\n'.join([s for s in a])"
+    "peptides = pd.read_csv(idir, sep = '\\t')\n",
+    "below_fdr = peptides['QValue'] <= 0.01\n",
+    "target = peptides['Decoy/Contaminant/Target'] == 'T'\n",
+    "peptides = peptides[below_fdr & target]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "peptides['Protein Accession'] = peptides['Protein Accession'].str.split('|')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "peptides = peptides.explode('Protein Accession')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "peptides = peptides[['Protein Accession', 'Base Sequence']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "peptide_dict = peptides.groupby('Base Sequence')['Protein Accession'].apply(list).to_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "protein_dict = peptides.groupby('Protein Accession')['Base Sequence'].apply(list).to_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "peptide_sizes = peptides.groupby('Base Sequence').size().reset_index().rename(columns = {0:'size'})\n",
+    "single = peptide_sizes[peptide_sizes['size'] == 1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inferred = peptides[peptides['Base Sequence'].isin(single['Base Sequence'])]\n",
+    "inferred = peptides[peptides['Protein Accession'].isin(inferred['Protein Accession'])]\n",
+    "remaining = peptides[~peptides['Protein Accession'].isin(inferred['Protein Accession'])]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_best_protein(remaining, original, protein_column):\n",
+    "    \"\"\"\n",
+    "    Finds best protein in remaining graph based on number\n",
+    "    of peptides a protein matches to (# of edges a protein has). Choose max\n",
+    "    If there are proteins with an equal number of maximum matched peptides\n",
+    "    then those proteins compared to the original graph for number of edges \n",
+    "    a protein has\n",
+    "    \"\"\"\n",
+    "    sizes = remaining.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})\n",
+    "    max_size = sizes['size'].max()\n",
+    "    best_proteins = list(sizes[sizes['size'] == max_size ][protein_column])\n",
+    "    if len(best_proteins) > 1:\n",
+    "        subset = original[original[protein_column].isin(best_proteins)]\n",
+    "        subsizes = subset.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})\n",
+    "        max_subsize = subsizes['size'].max()\n",
+    "        best_proteins = list(subsizes[subsizes['size'] == max_subsize])\n",
+    "    return best_proteins[0]\n",
+    "\n",
+    "\n",
+    "\n",
+    "def greedy_inference(original, protein_column = 'Protein Accession', peptide_column = 'Base Sequence'):\n",
+    "    \"\"\"\n",
+    "    Greedy protein inference algorithm for matching peptids to corresponding proteins\n",
+    "\n",
+    "    Notaion:\n",
+    "    G : original graph\n",
+    "    Gi : inferred graph\n",
+    "    Gr : remaining graph\n",
+    "    Gd: dropped graph\n",
+    "    p : greedily selcted protein\n",
+    "    s : peptides connected to p\n",
+    "\n",
+    "\n",
+    "    Select peptides in G that only match to single protein\n",
+    "    Add proteins corresponding to peptides and all attached peptides to Gi\n",
+    "    Remove said proteins from  Gr\n",
+    "    While Gr has edges connected proteins and peptides\n",
+    "        Greedily select best protein p\n",
+    "        Add p and connected peptides Gi\n",
+    "        Add peptide-protein edges where protein is not p and peptide is in s in Gd\n",
+    "        Remove edgees where peptides is in s from Gr\n",
+    "    \n",
+    "    Remake Gi and make Gd\n",
+    "        Gi remade to contain all protein-peptide edges that connect to an inferred protein\n",
+    "        Gd made to contain all protein-peptide edges that do not connect to an inferred protein\n",
+    "\n",
+    "    Parameters\n",
+    "    ---------\n",
+    "    original : pandas DataFrame\n",
+    "        original peptide-protien graph\n",
+    "    protein_column : str\n",
+    "        column associated with protein accession\n",
+    "    peptide_column : str\n",
+    "        column associated with peptide\n",
+    "\n",
+    "    Returns\n",
+    "    --------\n",
+    "    inferred: pandas DataFrame\n",
+    "        Gi, subgraph of G of proteins and their associated peptides\n",
+    "    dropped: pandas DataFrame\n",
+    "        Gd, subgraph of G of proteins and their associated peptides\n",
+    "\n",
+    "    \"\"\"\n",
+    "\n",
+    "    dropped = pd.DataFrame(columns = original.columns)\n",
+    "    peptide_sizes = original.groupby(peptide_column).size().reset_index().rename(columns = {0:'size'})\n",
+    "    single = peptide_sizes[peptide_sizes['size'] == 1]\n",
+    "    inferred = original[original[peptide_column].isin(single[peptide_column])]\n",
+    "    inferred = original[original[protein_column].isin(inferred[protein_column])]\n",
+    "    remaining = original[~original[protein_column].isin(inferred[protein_column])]\n",
+    "    inferred = [ inferred ]\n",
+    "    # dropped = []\n",
+    "\n",
+    "    while len(remaining) > 0:\n",
+    "        best_protein = find_best_protein(remaining, original, protein_column)\n",
+    "        matches = remaining[remaining[protein_column] == best_protein]\n",
+    "        tmp_peptides = list(matches[peptide_column])\n",
+    "        inferred.append(matches)\n",
+    "\n",
+    "        is_matched_peptide = remaining[peptide_column].isin(tmp_peptides)\n",
+    "        is_best_protein = remaining[protein_column] == best_protein\n",
+    "        # dropped.append( remaining[~is_best_protein & is_matched_peptide] )\n",
+    "        \n",
+    "        remaining = remaining[~is_matched_peptide]\n",
+    "        \n",
+    "    inferred = pd.concat(inferred)\n",
+    "    # dropped = pd.concat(dropped)\n",
+    "\n",
+    "    inferred_proteins = inferred[protein_column].unique()\n",
+    "    inferred = original[original[protein_column].isin(inferred_proteins)]\n",
+    "    dropped = original[~original[protein_column].isin(inferred_proteins)]\n",
+    "    \n",
+    "    return inferred, dropped\n",
+    " \n",
+    "\n",
+    "        \n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "start = time.time()\n",
+    "inferred, dropped = greedy_inference(peptides)\n",
+    "stop = time.time()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 149,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "a\n",
-      "b\n",
-      "c\n"
+      "36.61134672164917\n"
      ]
     }
    ],
    "source": [
-    "print(b)"
+    "print(stop-start)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Original 71672\nInferred 44025\nDropped 27647\nDropped + Inferred 71672\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Original {len(peptides)}\")\n",
+    "print(f\"Inferred {len(inferred)}\")\n",
+    "print(f\"Dropped {len(dropped)}\")\n",
+    "print(f\"Dropped + Inferred {len(dropped) + len(inferred)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "protein_bag = set()\n",
+    "for pep in peptide_bag:\n",
+    "    protein_bag = protein_bag.union(peptide_dict[pep])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for protein in protein_bag:\n",
+    "    peptide_bag = peptide_bag.union(protein_dict[protein])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "22413"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 65
+    }
+   ],
+   "source": [
+    "len(peptide_bag)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "13810"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 61
+    }
+   ],
+   "source": [
+    "len(single)"
    ]
   },
   {
@@ -104,7 +337,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/modules/PG_ProteinInference/protein_inference.ipynb
+++ b/modules/PG_ProteinInference/protein_inference.ipynb
@@ -2,129 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "import argparse\n",
-    "\n",
-    "import pandas as pd\n",
-    "\n",
-    "\n",
-    "def process_metamorpheus_file(filename):\n",
-    "    \"\"\"\n",
-    "    Process MetaMorpheus AllPeptides file \n",
-    "    Keeps only target peptieds with FDR <= 0.01\n",
-    "    Explodes 'Protein Accession' column into individual rows\n",
-    "\n",
-    "    Parameters\n",
-    "    ----------\n",
-    "    filename : str\n",
-    "        MetaMorpheus AllPeptides file location\n",
-    "    \n",
-    "    Returns\n",
-    "    --------\n",
-    "    original : pandas DataFrame\n",
-    "        exploded AllPeptieds dataframe\n",
-    "    \"\"\"\n",
-    "    original = pd.read_csv(filename, sep = '\\t')\n",
-    "    below_fdr = original['QValue'] <= 0.01\n",
-    "    target = original['Decoy/Contaminant/Target'] == 'T'\n",
-    "    original = original[below_fdr & target]\n",
-    "    original['Protein Accession'] = original['Protein Accession'].str.split('|')\n",
-    "    original = original.explode('Protein Accession')\n",
-    "    return original\n",
-    "\n",
-    "\n",
-    "def find_best_protein(remaining, original, protein_column):\n",
-    "    \"\"\"\n",
-    "    Finds best protein in remaining graph based on number\n",
-    "    of peptides a protein matches to (# of edges a protein has). Choose max\n",
-    "    If there are proteins with an equal number of maximum matched peptides\n",
-    "    then those proteins compared to the original graph for number of edges \n",
-    "    a protein has\n",
-    "    \"\"\"\n",
-    "    sizes = remaining.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})\n",
-    "    max_size = sizes['size'].max()\n",
-    "    best_proteins = list(sizes[sizes['size'] == max_size ][protein_column])\n",
-    "    if len(best_proteins) > 1:\n",
-    "        subset = original[original[protein_column].isin(best_proteins)]\n",
-    "        subsizes = subset.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})\n",
-    "        max_subsize = subsizes['size'].max()\n",
-    "        best_proteins = list(subsizes[subsizes['size'] == max_subsize][protein_column])\n",
-    "    return best_proteins[0]\n",
-    "\n",
-    "\n",
-    "\n",
-    "def greedy_inference(original, protein_column = 'Protein Accession', peptide_column = 'Base Sequence'):\n",
-    "    \"\"\"\n",
-    "    Greedy protein inference algorithm for matching peptids to corresponding proteins\n",
-    "\n",
-    "    Notaion:\n",
-    "    G : original graph\n",
-    "    Gi : inferred graph\n",
-    "    Gr : remaining graph\n",
-    "    Gd: dropped graph\n",
-    "    p : greedily selcted protein\n",
-    "    s : peptides connected to p\n",
-    "\n",
-    "\n",
-    "    Select peptides in G that only match to single protein\n",
-    "    Add proteins corresponding to peptides and all attached peptides to Gi\n",
-    "    Remove said proteins from  Gr\n",
-    "    While Gr has edges connected proteins and peptides\n",
-    "        Greedily select best protein p\n",
-    "        Add p and connected peptides Gi\n",
-    "        Add peptide-protein edges where protein is not p and peptide is in s in Gd\n",
-    "        Remove edgees where peptides is in s from Gr\n",
-    "    \n",
-    "    Remake Gi and make Gd\n",
-    "        Gi remade to contain all protein-peptide edges that connect to an inferred protein\n",
-    "        Gd made to contain all protein-peptide edges that do not connect to an inferred protein\n",
-    "\n",
-    "    Parameters\n",
-    "    ---------\n",
-    "    original : pandas DataFrame\n",
-    "        original peptide-protien graph\n",
-    "    protein_column : str\n",
-    "        column associated with protein accession\n",
-    "    peptide_column : str\n",
-    "        column associated with peptide\n",
-    "\n",
-    "    Returns\n",
-    "    --------\n",
-    "    inferred: pandas DataFrame\n",
-    "        Gi, subgraph of G of proteins and their associated peptides\n",
-    "    dropped: pandas DataFrame\n",
-    "        Gd, subgraph of G of proteins and their associated peptides\n",
-    "\n",
-    "    \"\"\"\n",
-    "\n",
-    "    # Find peptides that attach to only one protein\n",
-    "    # Add those proteins to inferred proteins bag\n",
-    "    # Remove any peptides that connect to inferred proteins\n",
-    "    peptide_sizes = original.groupby(peptide_column).size().reset_index().rename(columns = {0:'size'})\n",
-    "    single_peptides = list(peptide_sizes[peptide_sizes['size'] == 1][peptide_column])\n",
-    "    inferred_proteins = list(original[original[peptide_column].isin(single_peptides)][protein_column])\n",
-    "    attached_peptides = list(original[original[protein_column].isin(inferred_proteins)][peptide_column])\n",
-    "    \n",
-    "    remaining = original[~original[peptide_column].isin(attached_peptides)]\n",
-    "\n",
-    "    while len(remaining) > 0:\n",
-    "        # Greedy select best protein\n",
-    "        best_protein = find_best_protein(remaining, original, protein_column)\n",
-    "        inferred_proteins.append(best_protein)\n",
-    "        # Remove peptides that connect to protein from remaining\n",
-    "        attached_peptides = list(remaining[remaining[protein_column] == best_protein][peptide_column])\n",
-    "        is_matched_peptide = remaining[peptide_column].isin(attached_peptides)\n",
-    "        remaining = remaining[~is_matched_peptide]\n",
-    "    \n",
-    "    inferred = original[original[protein_column].isin(inferred_proteins)]\n",
-    "    dropped = original[~original[protein_column].isin(inferred_proteins)]\n",
-    "    \n",
-    "    return inferred, dropped\n",
-    " \n"
+    "import protein_inference"
    ]
   },
   {
@@ -134,151 +16,48 @@
    "outputs": [],
    "source": [
     "filename = '/Users/bj8th/Documents/Lab-for-Proteoform-Systems-Biology/data/peptides/AllPeptides_PacBio.psmtsv'\n",
-    "original = process_metamorpheus_file(filename)"
+    "original = protein_inference.process_metamorpheus_file(filename)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "22.31095004081726\n"
+      "25.1043918132782\n"
      ]
     }
    ],
    "source": [
     "import time\n",
     "start = time.time()\n",
-    "inferred, dropped = greedy_inference(original)\n",
+    "inferred, dropped, rescued = protein_inference.greedy_inference(original)\n",
     "stop = time.time()\n",
     "print(stop-start)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "57.87800621986389\n"
-     ]
-    }
-   ],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Original 71672\nInferred 36469\nDropped 35203\nDropped + Inferred 71672\n"
+      "Original \t\t71672\nInferred \t\t45322\nDropped \t\t26350\nDropped + Inferred \t71672\n"
      ]
     }
    ],
    "source": [
-    "print(f\"Original {len(original)}\")\n",
-    "print(f\"Inferred {len(inferred)}\")\n",
-    "print(f\"Dropped {len(dropped)}\")\n",
-    "print(f\"Dropped + Inferred {len(dropped) + len(inferred)}\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "inferred_set = inferred.groupby('Protein Accession')['Base Sequence'].apply(set)\n",
-    "dropped_set = dropped.groupby('Protein Accession')['Base Sequence'].apply(set)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "share_peptides = set()\n",
-    "# share_peptides = []\n",
-    "for d_acc, d_set in dropped_set.iteritems():\n",
-    "    for i_acc, i_set in inferred_set.iteritems():\n",
-    "        if d_set == i_set:\n",
-    "            share_peptides = share_peptides.union([d_acc])\n",
-    "            # share_peptides.append(d_acc)\n",
-    "   "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "13"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 38
-    }
-   ],
-   "source": [
-    "len(share_peptides)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "1256"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 36
-    }
-   ],
-   "source": [
-    "len(set(share_peptides))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "{'.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'B', 'P'}"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 39
-    }
-   ],
-   "source": [
-    "share_peptides"
+    "print(f\"Original \\t\\t{len(original)}\")\n",
+    "print(f\"Inferred \\t\\t{len(inferred)}\")\n",
+    "print(f\"Dropped \\t\\t{len(dropped)}\")\n",
+    "print(f\"Dropped + Inferred \\t{len(dropped) + len(inferred)}\")\n"
    ]
   },
   {

--- a/modules/PG_ProteinInference/protein_inference.ipynb
+++ b/modules/PG_ProteinInference/protein_inference.ipynb
@@ -2,106 +2,39 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "idir = '/Users/bj8th/Documents/Lab-for-Proteoform-Systems-Biology/data/peptides/AllPeptides_PacBio.psmtsv'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "peptides = pd.read_csv(idir, sep = '\\t')\n",
-    "below_fdr = peptides['QValue'] <= 0.01\n",
-    "target = peptides['Decoy/Contaminant/Target'] == 'T'\n",
-    "peptides = peptides[below_fdr & target]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "peptides['Protein Accession'] = peptides['Protein Accession'].str.split('|')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "peptides = peptides.explode('Protein Accession')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "peptides = peptides[['Protein Accession', 'Base Sequence']]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "peptide_dict = peptides.groupby('Base Sequence')['Protein Accession'].apply(list).to_dict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "protein_dict = peptides.groupby('Protein Accession')['Base Sequence'].apply(list).to_dict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "peptide_sizes = peptides.groupby('Base Sequence').size().reset_index().rename(columns = {0:'size'})\n",
-    "single = peptide_sizes[peptide_sizes['size'] == 1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 76,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "inferred = peptides[peptides['Base Sequence'].isin(single['Base Sequence'])]\n",
-    "inferred = peptides[peptides['Protein Accession'].isin(inferred['Protein Accession'])]\n",
-    "remaining = peptides[~peptides['Protein Accession'].isin(inferred['Protein Accession'])]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 147,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
+    "import pandas as pd\n",
+    "import argparse\n",
+    "\n",
+    "def process_metamorpheus_file(filename):\n",
+    "    \"\"\"\n",
+    "    Process MetaMorpheus AllPeptides file \n",
+    "    Keeps only target peptieds with FDR <= 0.01\n",
+    "    Explodes 'Protein Accession' column into individual rows\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    filename : str\n",
+    "        MetaMorpheus AllPeptides file location\n",
+    "    \n",
+    "    Returns\n",
+    "    --------\n",
+    "    original : pandas DataFrame\n",
+    "        exploded AllPeptieds dataframe\n",
+    "    \"\"\"\n",
+    "    original = pd.read_csv(filename, sep = '\\t')\n",
+    "    below_fdr = original['QValue'] <= 0.01\n",
+    "    target = original['Decoy/Contaminant/Target'] == 'T'\n",
+    "    original = original[below_fdr & target]\n",
+    "    original['Protein Accession'] = original['Protein Accession'].str.split('|')\n",
+    "    original = original.explode('Protein Accession')\n",
+    "    return original\n",
+    "\n",
+    "\n",
     "def find_best_protein(remaining, original, protein_column):\n",
     "    \"\"\"\n",
     "    Finds best protein in remaining graph based on number\n",
@@ -117,10 +50,15 @@
     "        subset = original[original[protein_column].isin(best_proteins)]\n",
     "        subsizes = subset.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})\n",
     "        max_subsize = subsizes['size'].max()\n",
-    "        best_proteins = list(subsizes[subsizes['size'] == max_subsize])\n",
+    "        best_proteins = list(subsizes[subsizes['size'] == max_subsize][protein_column])\n",
     "    return best_proteins[0]\n",
     "\n",
-    "\n",
+    "def rescue_indistinguishable(inferred, dropped):\n",
+    "    \"\"\"\n",
+    "    If a dropped protein has the exact match of peptides to an inferred protein then that protein is\n",
+    "    added into the inferred graph\n",
+    "    \"\"\"\n",
+    "    pass\n",
     "\n",
     "def greedy_inference(original, protein_column = 'Protein Accession', peptide_column = 'Base Sequence'):\n",
     "    \"\"\"\n",
@@ -173,7 +111,6 @@
     "    inferred = original[original[protein_column].isin(inferred[protein_column])]\n",
     "    remaining = original[~original[protein_column].isin(inferred[protein_column])]\n",
     "    inferred = [ inferred ]\n",
-    "    # dropped = []\n",
     "\n",
     "    while len(remaining) > 0:\n",
     "        best_protein = find_best_protein(remaining, original, protein_column)\n",
@@ -183,48 +120,47 @@
     "\n",
     "        is_matched_peptide = remaining[peptide_column].isin(tmp_peptides)\n",
     "        is_best_protein = remaining[protein_column] == best_protein\n",
-    "        # dropped.append( remaining[~is_best_protein & is_matched_peptide] )\n",
     "        \n",
     "        remaining = remaining[~is_matched_peptide]\n",
     "        \n",
     "    inferred = pd.concat(inferred)\n",
-    "    # dropped = pd.concat(dropped)\n",
     "\n",
     "    inferred_proteins = inferred[protein_column].unique()\n",
     "    inferred = original[original[protein_column].isin(inferred_proteins)]\n",
     "    dropped = original[~original[protein_column].isin(inferred_proteins)]\n",
     "    \n",
-    "    return inferred, dropped\n",
-    " \n",
-    "\n",
-    "        \n",
-    "\n",
-    "\n",
-    "\n"
+    "    return inferred, dropped"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
-    "start = time.time()\n",
-    "inferred, dropped = greedy_inference(peptides)\n",
-    "stop = time.time()\n"
+    "filename = '/Users/bj8th/Documents/Lab-for-Proteoform-Systems-Biology/data/peptides/AllPeptides_PacBio.psmtsv'\n",
+    "original = process_metamorpheus_file(filename)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "o"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "36.61134672164917\n"
+      "57.87800621986389\n"
      ]
     }
    ],
@@ -234,19 +170,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "Original 71672\nInferred 44025\nDropped 27647\nDropped + Inferred 71672\n"
+      "Original 71672\nInferred 44071\nDropped 27601\nDropped + Inferred 71672\n"
      ]
     }
    ],
    "source": [
-    "print(f\"Original {len(peptides)}\")\n",
+    "print(f\"Original {len(original)}\")\n",
     "print(f\"Inferred {len(inferred)}\")\n",
     "print(f\"Dropped {len(dropped)}\")\n",
     "print(f\"Dropped + Inferred {len(dropped) + len(inferred)}\")\n"
@@ -254,63 +190,65 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "protein_bag = set()\n",
-    "for pep in peptide_bag:\n",
-    "    protein_bag = protein_bag.union(peptide_dict[pep])\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for protein in protein_bag:\n",
-    "    peptide_bag = peptide_bag.union(protein_dict[protein])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "22413"
-      ]
+       "                     File Name  Scan Number  Scan Retention Time  \\\n",
+       "0  120426_Jurkat_highLC_Frac14        19149            140.45874   \n",
+       "1   120426_Jurkat_highLC_Frac9        19892            150.09205   \n",
+       "2  120426_Jurkat_highLC_Frac17        22894            167.51914   \n",
+       "3  120426_Jurkat_highLC_Frac23        14654            119.26644   \n",
+       "4  120426_Jurkat_highLC_Frac20        18563            142.91097   \n",
+       "\n",
+       "   Num Experimental Peaks  Total Ion Current  Precursor Scan Number  \\\n",
+       "0                   186.0       2.620926e+06                  19146   \n",
+       "1                   186.0       1.972297e+05                  19887   \n",
+       "2                   200.0       1.162710e+07                  22893   \n",
+       "3                   200.0       3.137383e+06                  14651   \n",
+       "4                   200.0       1.478450e+06                  18561   \n",
+       "\n",
+       "   Precursor Charge  Precursor MZ  Precursor Mass   Score  ...  \\\n",
+       "0               3.0    1187.22629      3558.65705  39.219  ...   \n",
+       "1               3.0    1221.90388      3662.68981  39.198  ...   \n",
+       "2               4.0     802.65041      3206.57254  39.164  ...   \n",
+       "3               4.0     771.14514      3080.55145  38.355  ...   \n",
+       "4               3.0    1240.64250      3718.90568  37.266  ...   \n",
+       "\n",
+       "   Localized Scores  Improvement Possible Cumulative Target Cumulative Decoy  \\\n",
+       "0                                                         1                0   \n",
+       "1                                                         2                0   \n",
+       "2                                                         3                0   \n",
+       "3                                                         4                0   \n",
+       "4                                                         5                0   \n",
+       "\n",
+       "  QValue  Cumulative Target Notch Cumulative Decoy Notch QValue Notch  \\\n",
+       "0    0.0                        1                      0          0.0   \n",
+       "1    0.0                        2                      0          0.0   \n",
+       "2    0.0                        3                      0          0.0   \n",
+       "3    0.0                        4                      0          0.0   \n",
+       "4    0.0                        5                      0          0.0   \n",
+       "\n",
+       "        PEP  PEP_QValue  \n",
+       "0  0.000028    0.000017  \n",
+       "1  0.000006    0.000003  \n",
+       "2  0.000004    0.000002  \n",
+       "3  0.002980    0.000382  \n",
+       "4  0.000013    0.000008  \n",
+       "\n",
+       "[5 rows x 54 columns]"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>File Name</th>\n      <th>Scan Number</th>\n      <th>Scan Retention Time</th>\n      <th>Num Experimental Peaks</th>\n      <th>Total Ion Current</th>\n      <th>Precursor Scan Number</th>\n      <th>Precursor Charge</th>\n      <th>Precursor MZ</th>\n      <th>Precursor Mass</th>\n      <th>Score</th>\n      <th>...</th>\n      <th>Localized Scores</th>\n      <th>Improvement Possible</th>\n      <th>Cumulative Target</th>\n      <th>Cumulative Decoy</th>\n      <th>QValue</th>\n      <th>Cumulative Target Notch</th>\n      <th>Cumulative Decoy Notch</th>\n      <th>QValue Notch</th>\n      <th>PEP</th>\n      <th>PEP_QValue</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>120426_Jurkat_highLC_Frac14</td>\n      <td>19149</td>\n      <td>140.45874</td>\n      <td>186.0</td>\n      <td>2.620926e+06</td>\n      <td>19146</td>\n      <td>3.0</td>\n      <td>1187.22629</td>\n      <td>3558.65705</td>\n      <td>39.219</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>1</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>1</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000028</td>\n      <td>0.000017</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>120426_Jurkat_highLC_Frac9</td>\n      <td>19892</td>\n      <td>150.09205</td>\n      <td>186.0</td>\n      <td>1.972297e+05</td>\n      <td>19887</td>\n      <td>3.0</td>\n      <td>1221.90388</td>\n      <td>3662.68981</td>\n      <td>39.198</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>2</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>2</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000006</td>\n      <td>0.000003</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>120426_Jurkat_highLC_Frac17</td>\n      <td>22894</td>\n      <td>167.51914</td>\n      <td>200.0</td>\n      <td>1.162710e+07</td>\n      <td>22893</td>\n      <td>4.0</td>\n      <td>802.65041</td>\n      <td>3206.57254</td>\n      <td>39.164</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>3</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>3</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000004</td>\n      <td>0.000002</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>120426_Jurkat_highLC_Frac23</td>\n      <td>14654</td>\n      <td>119.26644</td>\n      <td>200.0</td>\n      <td>3.137383e+06</td>\n      <td>14651</td>\n      <td>4.0</td>\n      <td>771.14514</td>\n      <td>3080.55145</td>\n      <td>38.355</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>4</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>4</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.002980</td>\n      <td>0.000382</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>120426_Jurkat_highLC_Frac20</td>\n      <td>18563</td>\n      <td>142.91097</td>\n      <td>200.0</td>\n      <td>1.478450e+06</td>\n      <td>18561</td>\n      <td>3.0</td>\n      <td>1240.64250</td>\n      <td>3718.90568</td>\n      <td>37.266</td>\n      <td>...</td>\n      <td></td>\n      <td></td>\n      <td>5</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>5</td>\n      <td>0</td>\n      <td>0.0</td>\n      <td>0.000013</td>\n      <td>0.000008</td>\n    </tr>\n  </tbody>\n</table>\n<p>5 rows × 54 columns</p>\n</div>"
      },
      "metadata": {},
-     "execution_count": 65
+     "execution_count": 18
     }
    ],
    "source": [
-    "len(peptide_bag)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "13810"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 61
-    }
-   ],
-   "source": [
-    "len(single)"
+    "inferred.head()"
    ]
   },
   {

--- a/modules/PG_ProteinInference/protein_inference.py
+++ b/modules/PG_ProteinInference/protein_inference.py
@@ -99,7 +99,7 @@ def greedy_inference(original, protein_column = 'Protein Accession', peptide_col
     peptide_sizes = original.groupby(peptide_column).size().reset_index().rename(columns = {0:'size'})
     single_peptides = list(peptide_sizes[peptide_sizes['size'] == 1][peptide_column])
     inferred_proteins = list(original[original[peptide_column].isin(single_peptides)][protein_column])
-    attached_peptides = list(original[original[protein_column].isin(inferred_proteins)][peptide_column])
+    attached_peptides = set(original[original[protein_column].isin(inferred_proteins)][peptide_column])
     remaining = original[~original[peptide_column].isin(attached_peptides)]
 
     while len(remaining) > 0:
@@ -107,7 +107,7 @@ def greedy_inference(original, protein_column = 'Protein Accession', peptide_col
         best_protein = find_best_protein(remaining, original, protein_column)
         inferred_proteins.append(best_protein)
         # Remove peptides that connect to protein from remaining
-        attached_peptides = list(remaining[remaining[protein_column] == best_protein][peptide_column])
+        attached_peptides = set(remaining[remaining[protein_column] == best_protein][peptide_column])
         is_matched_peptide = remaining[peptide_column].isin(attached_peptides)
         remaining = remaining[~is_matched_peptide]
     

--- a/modules/PG_ProteinInference/protein_inference.py
+++ b/modules/PG_ProteinInference/protein_inference.py
@@ -1,0 +1,139 @@
+
+import pandas as import pd
+import argparse
+
+def process_metamorpheus_file(filename):
+    """
+    Process MetaMorpheus AllPeptides file 
+    Keeps only target peptieds with FDR <= 0.01
+    Explodes 'Protein Accession' column into individual rows
+
+    Parameters
+    ----------
+    filename : str
+        MetaMorpheus AllPeptides file location
+    
+    Returns
+    --------
+    original : pandas DataFrame
+        exploded AllPeptieds dataframe
+    """
+    original = pd.read_csv(filename, sep = '\t')
+    below_fdr = original['QValue'] <= 0.01
+    target = original['Decoy/Contaminant/Target'] == 'T'
+    original = original[below_fdr & target]
+    original['Protein Accession'] = original['Protein Accession'].str.split('|')
+    original = original.explode('Protein Accession')
+    return original
+
+
+def find_best_protein(remaining, original, protein_column):
+    """
+    Finds best protein in remaining graph based on number
+    of peptides a protein matches to (# of edges a protein has). Choose max
+    If there are proteins with an equal number of maximum matched peptides
+    then those proteins compared to the original graph for number of edges 
+    a protein has
+    """
+    sizes = remaining.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})
+    max_size = sizes['size'].max()
+    best_proteins = list(sizes[sizes['size'] == max_size ][protein_column])
+    if len(best_proteins) > 1:
+        subset = original[original[protein_column].isin(best_proteins)]
+        subsizes = subset.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})
+        max_subsize = subsizes['size'].max()
+        best_proteins = list(subsizes[subsizes['size'] == max_subsize])
+    return best_proteins[0]
+
+
+
+def greedy_inference(original, protein_column = 'Protein Accession', peptide_column = 'Base Sequence'):
+    """
+    Greedy protein inference algorithm for matching peptids to corresponding proteins
+
+    Notaion:
+    G : original graph
+    Gi : inferred graph
+    Gr : remaining graph
+    Gd: dropped graph
+    p : greedily selcted protein
+    s : peptides connected to p
+
+
+    Select peptides in G that only match to single protein
+    Add proteins corresponding to peptides and all attached peptides to Gi
+    Remove said proteins from  Gr
+    While Gr has edges connected proteins and peptides
+        Greedily select best protein p
+        Add p and connected peptides Gi
+        Add peptide-protein edges where protein is not p and peptide is in s in Gd
+        Remove edgees where peptides is in s from Gr
+    
+    Remake Gi and make Gd
+        Gi remade to contain all protein-peptide edges that connect to an inferred protein
+        Gd made to contain all protein-peptide edges that do not connect to an inferred protein
+
+    Parameters
+    ---------
+    original : pandas DataFrame
+        original peptide-protien graph
+    protein_column : str
+        column associated with protein accession
+    peptide_column : str
+        column associated with peptide
+
+    Returns
+    --------
+    inferred: pandas DataFrame
+        Gi, subgraph of G of proteins and their associated peptides
+    dropped: pandas DataFrame
+        Gd, subgraph of G of proteins and their associated peptides
+
+    """
+
+    dropped = pd.DataFrame(columns = original.columns)
+    peptide_sizes = original.groupby(peptide_column).size().reset_index().rename(columns = {0:'size'})
+    single = peptide_sizes[peptide_sizes['size'] == 1]
+    inferred = original[original[peptide_column].isin(single[peptide_column])]
+    inferred = original[original[protein_column].isin(inferred[protein_column])]
+    remaining = original[~original[protein_column].isin(inferred[protein_column])]
+    inferred = [ inferred ]
+
+    while len(remaining) > 0:
+        best_protein = find_best_protein(remaining, original, protein_column)
+        matches = remaining[remaining[protein_column] == best_protein]
+        tmp_peptides = list(matches[peptide_column])
+        inferred.append(matches)
+
+        is_matched_peptide = remaining[peptide_column].isin(tmp_peptides)
+        is_best_protein = remaining[protein_column] == best_protein
+        
+        remaining = remaining[~is_matched_peptide]
+        
+    inferred = pd.concat(inferred)
+
+    inferred_proteins = inferred[protein_column].unique()
+    inferred = original[original[protein_column].isin(inferred_proteins)]
+    dropped = original[~original[protein_column].isin(inferred_proteins)]
+    
+    return inferred, dropped
+ 
+
+def main():
+    parser = argparse.ArgumentParser(description='Parse Greedy Protein Inference Arguments')
+    parser.add_argument('-ifile', action='store',dest='ifile', help = 'input peptide-protein file')
+    parser.add_argument('-odir', action = 'store', dest='odir', help = 'output directory for results')
+    results = parser.parse_args()
+
+    original = process_metamorpheus_file(results.ifile)
+    inferred, dropped = greedy_inference(original)
+    inferred.to_csv('inferred_proteins.tsv', sep = '\t', index = False)
+    dropped.to_csv('dropped_proteins.tsv', sep = '\t', index=False)
+
+if __name__ == "__main__":
+    main()
+
+        
+
+
+

--- a/modules/PG_ProteinInference/protein_inference.py
+++ b/modules/PG_ProteinInference/protein_inference.py
@@ -1,6 +1,8 @@
 
-import pandas as import pd
 import argparse
+
+import pandas as pd
+
 
 def process_metamorpheus_file(filename):
     """
@@ -42,7 +44,7 @@ def find_best_protein(remaining, original, protein_column):
         subset = original[original[protein_column].isin(best_proteins)]
         subsizes = subset.groupby(protein_column).size().reset_index().rename(columns = {0:'size'})
         max_subsize = subsizes['size'].max()
-        best_proteins = list(subsizes[subsizes['size'] == max_subsize])
+        best_proteins = list(subsizes[subsizes['size'] == max_subsize][protein_column])
     return best_proteins[0]
 
 
@@ -121,14 +123,14 @@ def greedy_inference(original, protein_column = 'Protein Accession', peptide_col
 
 def main():
     parser = argparse.ArgumentParser(description='Parse Greedy Protein Inference Arguments')
-    parser.add_argument('-ifile', action='store',dest='ifile', help = 'input peptide-protein file')
-    parser.add_argument('-odir', action = 'store', dest='odir', help = 'output directory for results')
+    parser.add_argument('-i','--ifile', action='store',dest='ifile', help = 'input peptide-protein file')
+    parser.add_argument('-o','--odir', action = 'store', dest='odir', help = 'output directory for results')
     results = parser.parse_args()
 
     original = process_metamorpheus_file(results.ifile)
     inferred, dropped = greedy_inference(original)
-    inferred.to_csv('inferred_proteins.tsv', sep = '\t', index = False)
-    dropped.to_csv('dropped_proteins.tsv', sep = '\t', index=False)
+    inferred.to_csv(f'{results.odir}/inferred_proteins.tsv', sep = '\t', index = False)
+    dropped.to_csv(f'{results.odir}/dropped_proteins.tsv', sep = '\t', index=False)
 
 if __name__ == "__main__":
     main()

--- a/modules/PG_ProteinInference/protein_inference.py
+++ b/modules/PG_ProteinInference/protein_inference.py
@@ -130,7 +130,7 @@ def rescue_matched_proteins(inferred, dropped, protein_column = 'Protein Accessi
     for d_acc, d_set in dropped_set.iteritems():
         for i_acc, i_set in inferred_set.iteritems():
             if d_set == i_set:
-                rescued_proteins = share_peptides.union([d_acc])
+                rescued_proteins = rescued_proteins.union([d_acc])
                 break
     
     rescued = dropped[dropped[protein_column].isin(rescued_proteins)]


### PR DESCRIPTION
**Protein inference algorithm using greedy algorithm implemented in production MetaMorpheus.**

1. Find peptides that only connect to single protein
2. Find proteins associated with peptides
3. Remove all peptides associated with proteins from remaining graph (Gr)

4. Greedily select best protein
    4a. Choose protein that has highest number of connected peptides in Gr
    4b. If multiple proteins compare number of peptides connected in original graph
5. Add protein to inferred protein set
6. Remove all peptides associated with protein from Gr
7. Repeat 4-6 until no edges remain in Gr

8. Rescue proteins that were dropped where set of peptides connected to protein exactly matches peptide set of a protein in the inferred proteins