### PR TITLE
Patch to enable large file deletion from git history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+
+# large file formats
+*fa.gz
 .DS_Store
 .vscode
 #nextflow related files

--- a/main.nf
+++ b/main.nf
@@ -120,7 +120,7 @@ else{
 
 if (params.mass_spec != false & params.rescue_resolve_toml == false){
   exit 1, "Cannot find file for parameter --rescue_resolve_toml: ${params.rescue_resolve_toml}"
-}else if (params.mass_spec == true & params.rescue_resolve_toml == true){
+}else if (params.mass_spec != false & params.rescue_resolve_toml != false){
   ch_rr_toml = Channel.value(file(params.rescue_resolve_toml))
 }else{
   ch_rr_toml = Channel.from("no mass spec")
@@ -735,13 +735,12 @@ process metamorpheus_with_sample_specific_database{
 }
 
 process metamorpheus_with_sample_specific_database_rescue_resolve{
-    tag " $mass_spec"
+    tag " $mass_spec $orf_fasta $orf_meta  $toml"
     publishDir "${params.outdir}/metamorpheus/rescue_resolve", mode: 'copy'
 
     input:
         // file(orf_calls) from ch_orf_calls
         file(orf_fasta) from ch_refined_fasta_rescue_resolve
-        // file(toml) from ch_toml
         file(mass_spec) from ch_mass_spec_for_pacbio_rescue_resolve.collect()
         file(toml) from ch_rr_toml
         file(orf_meta) from ch_refined_info_rescue_resolve

--- a/modules/peptide_novelty_analysis/peptide_novelty_analysis.py
+++ b/modules/peptide_novelty_analysis/peptide_novelty_analysis.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+# script to find novel peptides that only exist in pacbio data
+# but not reference databases (e.g., gencode)

--- a/nextflow.config
+++ b/nextflow.config
@@ -80,7 +80,7 @@ process {
     withName: metamorpheus_with_uniprot_database{
         container = 'smithchemwisc/metamorpheus:lrproteogenomics'
     }
-    withName: metamorpheus_with_sample_specific_database{
+    withName: metamorpheus_with_sample_specific_database_rescue_resolve{
         container = 'smithchemwisc/metamorpheus:lrproteogenomics'
     }
     withName: mass_spec_raw_convert {


### PR DESCRIPTION
## Overview

Patch to enable large file deletion from git history.
Commits from `main` were removed by resetting HEAD force pushing

See this draft PR for more info
https://github.com/sheynkman-lab/Long-Read-Proteogenomics/pull/134.

## Changes

- Adds `fa.gz` in `.gitignore`
- set toml file
-  metamorpehus rr point to correct docker
- Add folder to initiate peptide novelty script.

## Failed tests

The test is failing on the Metamorpheus step. However we choose to merge this as @bj8th is working on fixing this, and the scope of this PR is to restore the state of the repo.

![image](https://user-images.githubusercontent.com/38183826/111919370-8adbb180-8a81-11eb-87f3-fae4753345bc.png)
