### PR TITLE
Minor refactor of --metamorpheus_toml [debugs cloud execution]

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -34,7 +34,7 @@ params {
    lower_kb                  = 1
    mass_spec                 = 'https://zenodo.org/record/5111831/files/mass_spec_test.tar.gz'
    max_cpus                  = 2
-   metamorpheus_toml         = 'NO_TOML_FILE'
+   metamorpheus_toml         = false
    name                      = 'jurkat_chr22'
    protein_coding_only       = false
    rescue_resolve_toml       = 'https://zenodo.org/record/5111831/files/Task1SearchTaskconfig_rescue_resolve.toml'

--- a/main.nf
+++ b/main.nf
@@ -142,10 +142,17 @@ if (!params.sqanti_fasta == false) {
 
 ch_fastq_reads = Channel.from(params.fastq_read_1, params.fastq_read_2).filter(String).flatMap{ files(it) }
 
-if (params.metamorpheus_toml != false){
-   ch_metamorpheus_toml = Channel.value(file(params.metamorpheus_toml))
-} else {
-   ch_metamorpheus_toml = Channel.value(file("NO_TOML_FILE"))
+// Implements logic for cloud compatibility, NO_TOML_FILE as variable only works for envs with local file system
+projectDir = workflow.projectDir
+
+if (!params.toml_file) {
+    log.warn "No toml file specified via --toml_file for Metamorpheus, proceeding without"
+    ch_metamorpheus_toml = Channel.value(file("${projectDir}/assets/NO_TOML_FILE"))
+}
+
+if (params.toml_file) {
+    log.warn "Metamorpheus toml file specified: ${params.toml_file}"
+    ch_metamorpheus_toml = Channel.value(file(params.metamorpheus_toml))
 }
 
 ch_metamorpheus_toml.into{

--- a/main.nf
+++ b/main.nf
@@ -145,13 +145,13 @@ ch_fastq_reads = Channel.from(params.fastq_read_1, params.fastq_read_2).filter(S
 // Implements logic for cloud compatibility, NO_TOML_FILE as variable only works for envs with local file system
 projectDir = workflow.projectDir
 
-if (!params.toml_file) {
-    log.warn "No toml file specified via --toml_file for Metamorpheus, proceeding without"
+if (!params.metamorpheus_toml) {
+    log.warn "No toml file specified via --metamorpheus_toml for Metamorpheus, proceeding without"
     ch_metamorpheus_toml = Channel.value(file("${projectDir}/assets/NO_TOML_FILE"))
 }
 
-if (params.toml_file) {
-    log.warn "Metamorpheus toml file specified: ${params.toml_file}"
+if (params.metamorpheus_toml) {
+    log.warn "Metamorpheus toml file specified: ${params.metamorpheus_toml}"
     ch_metamorpheus_toml = Channel.value(file(params.metamorpheus_toml))
 }
 
@@ -2005,7 +2005,6 @@ def logHeader() {
     -${c_dim}--------------------------------------------------${c_reset}-
     """.stripIndent()
 }
-
 
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,7 +41,7 @@ params {
   coding_score_cutoff = 0.0
 
   mass_spec = false
-  metamorpheus_toml = 'NO_TOML_FILE'
+  metamorpheus_toml = false
   rescue_resolve_toml = false
 
   sqanti_classification = false


### PR DESCRIPTION
<!--
# sheynkman-lab/Long-Read-Proteogenomics pull request

Many thanks for contributing to sheynkman-lab/Long-Read-Proteogenomics!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.
-->

## tl;dr

Bug fix to allow cloud execution (currently only works for local) when a toml file is not provided for Metamorpheus via `--metamorpheus_toml`

## Overview

This change addresses a bug introduced with the `NO_TOML_FILE` logic used as a value instead of file. The bug was found because @adeslatt and @bj8th mentioned that the test config without **sqanti** was not running in the cloud.
The former implementation allows for successful execution of the pipeline only in environments with a local file system (HPC, personal computer etc).

When running in the cloud, the absence of the `NO_TOML_FILE` actual file makes the pipeline to fail.
For an example of the failed job see here:

https://cloudos.lifebit.ai/public/jobs/60faf24695a1d6019a1faa70

![](http://g.recordit.co/aGNlK2nHtK.gif)

The Github revision (commit) of the failed execution is 7ebe304 (current `main` branch latest commit).

## Implementation

The refactor is minor, the change mainly relies on the addition of a pseudo file, inside the assets folder named `NO_TOML_FILE` (see `Files changed` `4`  in the 4th PR tab above to inspect).

With this, the logic is modified to:

a. If toml provided, then create the input channel from the provided file
b. If toml NOT provided, then create the input channel from the pseudo NO_TOML_FILE file to avoid the reported above bug,

https://github.com/sheynkman-lab/Long-Read-Proteogenomics/blob/0befbb0d2804d3239dca8d59ebb4a1531328d8e5/main.nf#L145-L156

## Instructions for PR reviewers

### with a Linux laptop/computer

Skip this section, you don't need to do anything

### with a Mac laptop/computer


<summary>   Expand the `Details` section below and follow the instructions below before you use Docker locally (memory configuration)
   </summary>

<details>

Click in your desktop Docker app **Preferences** > **Resources** and set the values to:

CPUs: 4
Memory: 6GB
SWAP: 3GB


![image](https://user-images.githubusercontent.com/38183826/126847131-eee9e34a-56a9-4a4f-ac2a-b70ed7a84df0.png)


For me only this addressed the memory issues from Metamorpheus processes


</details>

To reproduce the test with this new change, you can in a clean non-git working directory, with **docker**  and **conda**  available, 
you can directly copy and paste the following commands in the given sequence:


```bash
# (Optional) Install Nextflow if not available
conda install -c bioconda nextflow -y

# Set Nextflow version same with the one in CloudOS
export NXF_VER=20.01.0

# Clone from scratch the repo in a new directory to avoid local conflicts or out of date code
mkdir ~/pr-test-dir
cd ~/pr-test-dir
git clone https://github.com/sheynkman-lab/Long-Read-Proteogenomics
cd Long-Read-Proteogenomics

# Checkout to the tag that corresponds to the fix (created for the PR review, will delete after)
# This corresponds to this tagged snapshot: 
# https://github.com/sheynkman-lab/Long-Read-Proteogenomics/releases/tag/toml-cloud-native-tag
git checkout toml-cloud-native-tag

# NOTE!  You should now see "HEAD is now at 0befbb0 New NO_TOML_FILE logic for env agnostic execution" (ignore other lines)

# Run the pipeline with the test_without_sqanti.config with the exact commit of the latest changes of the new branch
nextflow run main.nf --config conf/test_without_sqanti.config 
```

Estimated execution time with 4 cpus and 8GB RAM: 
The run should finish successfully and you should see sth similar to the screenshot below:

<summary> </summary>

<details>

```console
(nf) admin@x86_64-apple-darwin13 Long-Read-Proteogenomics % git log -1                                                                    
commit 0befbb0d2804d3239dca8d59ebb4a1531328d8e5 (HEAD, tag: toml-cloud-native-tag, origin/toml-cloud-native)
Author: cgpu <chatzipantsiou@gmail.com>
Date:   Fri Jul 23 18:48:16 2021 +0100

New NO_TOML_FILE logic for env agnostic execution
(nf) admin@x86_64-apple-darwin13 Long-Read-Proteogenomics % time nextflow run . --config conf/test_without_sqanti.config -resume
N E X T F L O W  ~  version 20.04.1
Launching `./main.nf` [insane_kowalevski] - revision: 3b27cbc9a9
WARN: It appears you have never run this project before -- Option `-resume` is ignored
Longread Proteogenomics - N F  ~  version 0.1
=====================================
PARAMETERS SUMMARY
coding_score_cutoff                   : 0.0
config                                : conf/test_without_sqanti.config
fastq_read_1                          : false
fastq_read_2                          : false
gencode_gtf                           : https://zenodo.org/record/5125499/files/gencode.v35.annotation.chr22.gtf
gencode_transcript_fasta              : https://zenodo.org/record/5125499/files/gencode.v35.pc_transcripts.chr22.fa
gencode_translation_fasta             : https://zenodo.org/record/5125499/files/gencode_protein.chr22.fasta
genome_fasta                          : https://zenodo.org/record/5125499/files/GRCh38.primary_assembly.genome.chr22.fa
hexamer                               : https://zenodo.org/record/5125499/files/Human_Hexamer.tsv
logit_model                           : https://zenodo.org/record/5125499/files/Human_logitModel.RData.gz
mainScript                            : main.nf
mass_spec                             : https://zenodo.org/record/5125499/files/mass_spec_test.tar.gz
max_cpus                              : 2
metamorpheus toml                     : false
name                                  : jurkat_chr22
normalized_ribo_kallisto              : https://zenodo.org/record/5125499/files/kallist_table_rdeplete_jurkat.tsv
outdir                                : ./results
primers_fasta                         : https://zenodo.org/record/5125499/files/NEB_primers.fasta
rescue and resolve toml               : https://zenodo.org/record/5125499/files/Task1SearchTaskconfig_rescue_resolve.toml
sample_ccs                            : https://zenodo.org/record/5125499/files/jurkat.codethon_toy.ccs.bam
sample_kallisto_tpm                   : https://zenodo.org/record/5125499/files/jurkat_gene_kallisto.tsv
sqanti classification                 : https://zenodo.org/record/5125499/files/jurkat_chr22_classification.txt
sqanti fasta                          : https://zenodo.org/record/5125499/files/jurkat_chr22_corrected.fasta
sqanti gtf                            : https://zenodo.org/record/5125499/files/jurkat_chr22_corrected.gtf
star_genome_dir                       : false
uniprot_protein_fasta                 : https://zenodo.org/record/5125499/files/uniprot_protein.chr22.fasta

WARN: Access to undefined parameter `toml_file` -- Initialise it to a default value eg. `params.toml_file = some_value`
WARN: No toml file specified via --toml_file for Metamorpheus, proceeding without
executor >  local (21)
executor >  local (23)
executor >  local (23)
executor >  local (23)
executor >  local (28)
[51/92b8f1] process > gunzip_logit_model (decompress logit model)                                                                                                                                                    [100%] 1 of 1 ✔
executor >  local (30)
[51/92b8f1] process > gunzip_logit_model (decompress logit model)                                                                                                                                                                                                     [100%] 1 of 1 ✔
executor >  local (30)
[51/92b8f1] process > gunzip_logit_model (decompress logit model)                                                                                                                                                                                                     [100%] 1 of 1 ✔
executor >  local (33)
[51/92b8f1] process > gunzip_logit_model (decompress logit model)                                                                                                                                                                                                     [100%] 1 of 1 ✔
executor >  local (33)
[51/92b8f1] process > gunzip_logit_model (decompress logit model)                                                                                                                                                                                                     [100%] 1 of 1 ✔
[b4/49c31b] process > untar_mass_spec (mass_spec_test.tar.gz)                                                                                                                                                                                                         [100%] 1 of 1 ✔
[b4/5c2303] process > generate_reference_tables (gencode.v35.annotation.chr22.gtf, gencode.v35.pc_transcripts.chr22.fa)                                                                                                                                               [100%] 1 of 1 ✔
[a1/eed3d7] process > make_gencode_database (gencode_protein.chr22.fasta)                                                                                                                                                                                             [100%] 1 of 1 ✔
[bb/9e528b] process > filter_sqanti                                                                                                                                                                                                                                   [100%] 1 of 1 ✔
[3f/6863f8] process > six_frame_translation (jurkat_chr22_classification.5degfilter.tsv, ensg_gene.tsv)                                                                                                                                                               [100%] 1 of 1 ✔
[0e/1f526e] process > transcriptome_summary                                                                                                                                                                                                                           [100%] 1 of 1 ✔
[fc/5935e5] process > cpat (Human_Hexamer.tsv, Human_logitModel.RData, jurkat_chr22_corrected.5degfilter.fasta)                                                                                                                                                       [100%] 1 of 1 ✔
[2d/a590d3] process > orf_calling (null, gencode.v35.annotation.chr22.gtf, jurkat_chr22_corrected.5degfilter.gff, pb_gene.tsv, jurkat_chr22_classification.5degfilter.tsv, jurkat_chr22_corrected.5degfilter.fasta )                                                  [100%] 1 of 1 ✔
[a0/ec875b] process > refine_orf_database (jurkat_chr22_best_orf.tsv, jurkat_chr22_corrected.5degfilter.fasta, 0.0)                                                                                                                                                   [100%] 1 of 1 ✔
[be/9a4cfc] process > make_pacbio_cds_gtf                                                                                                                                                                                                                             [100%] 1 of 1 ✔
[fb/db5ba4] process > rename_cds_to_exon (jurkat_chr22 gencode.v35.annotation.chr22.gtf jurkat_chr22_with_cds.gtf)                                                                                                                                                    [100%] 1 of 1 ✔
[3e/4477fa] process > sqanti_protein                                                                                                                                                                                                                                  [100%] 1 of 1 ✔
[76/b36704] process > five_prime_utr                                                                                                                                                                                                                                  [100%] 1 of 1 ✔
[5a/f17869] process > protein_classification                                                                                                                                                                                                                          [100%] 1 of 1 ✔
[93/323048] process > protein_gene_rename                                                                                                                                                                                                                             [100%] 1 of 1 ✔
[e4/b4eda7] process > filter_protein                                                                                                                                                                                                                                  [100%] 1 of 1 ✔
[8a/c00415] process > make_hybrid_database                                                                                                                                                                                                                            [100%] 1 of 1 ✔
[06/e4c7e2] process > mass_spec_raw_convert                                                                                                                                                                                                                           [100%] 1 of 1 ✔
[6a/55ac84] process > metamorpheus_with_gencode_database ([120426_Jurkat_highLC_Frac15.mzML, 120426_Jurkat_highLC_Frac22.mzML])                                                                                                                                       [100%] 1 of 1 ✔
[24/5aa590] process > metamorpheus_with_uniprot_database ([120426_Jurkat_highLC_Frac15.mzML, 120426_Jurkat_highLC_Frac22.mzML])                                                                                                                                       [100%] 1 of 1 ✔
[2c/18260c] process > metamorpheus_with_sample_specific_database_refined ([120426_Jurkat_highLC_Frac15.mzML, 120426_Jurkat_highLC_Frac22.mzML])                                                                                                                       [100%] 1 of 1 ✔[69/88ff87] process > metamorpheus_with_sample_specific_database_filtered ([120426_Jurkat_highLC_Frac15.mzML, 120426_Jurkat_highLC_Frac22.mzML])                                                                                                                      [100%] 1 of 1 ✔[49/073731] process > metamorpheus_with_sample_specific_database_hybrid ([120426_Jurkat_highLC_Frac15.mzML, 120426_Jurkat_highLC_Frac22.mzML])                                                                                                                        [100%] 1 of 1 ✔[a8/ecc7d6] process > metamorpheus_with_sample_specific_database_rescue_resolve ( [120426_Jurkat_highLC_Frac15.mzML, 120426_Jurkat_highLC_Frac22.mzML] jurkat_chr22_hybrid.fasta jurkat_chr22_refined_high_confidence.tsv  Task1SearchTaskconfig_rescue_resolve.toml) [100%] 1 of 1 ✔[69/8e1423] process > peptide_analysis                                                                                                                                                                                                                                [100%] 1 of 1 ✔[a1/151d96] process > gencode_track_visualization                                                                                                                                                                                                                     [100%] 1 of 1 ✔
[b1/b1ba08] process > protein_track_visualization                                                                                                                                                                                                                     [100%] 1 of 1 ✔[a7/6f4394] process > make_multiregion                                                                                                                                                                                                                                [100%] 1 of 1 ✔
[13/4cb98c] process > peptide_track_visualization                                                                                                                                                                                                                     [100%] 1 of 1 ✔[c5/048fe1] process > accession_mapping                                                                                                                                                                                                                               [100%] 1 of 1 ✔
[c9/8d6a31] process > protein_group_compare                                                                                                                                                                                                                           [100%] 1 of 1 ✔[db/4894f6] process > peptide_novelty_analysis                                                                                                                                                                                                                        [100%] 1 of 1 ✔
WARN: Failed to publish file: /Users/admin/pr-test-dir/Long-Read-Proteogenomics/work/a8/ecc7d668894a5fc0affb7687c9a343/search_results/Task1SearchTask/AllQuantifiedProteinGroups.jurkat_chr22.rescue_resolve.tsv; to: /Users/admin/pr-test-dir/Long-Read-Proteogenomics/results/jurkat_chr22/metamorpheus/pacbio/rescue_resolve/search_results/Task1SearchTask/AllQuantifiedProteinGroups.jurkat_chr22.rescue_resolve.tsv [copy] -- See log file for details
WARN: Failed to publish file: /Users/admin/pr-test-dir/Long-Read-Proteogenomics/work/a8/ecc7d668894a5fc0affb7687c9a343/search_results/Task1SearchTask/AllPeptides.jurkat_chr22.rescue_resolve.psmtsv; to: /Users/admin/pr-test-dir/Long-Read-Proteogenomics/results/jurkat_chr22/metamorpheus/pacbio/rescue_resolve/search_results/Task1SearchTask/AllPeptides.jurkat_chr22.rescue_resolve.psmtsv [copy] -- See log file for details
WARN: To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org for more info.
Completed at: 23-Jul-2021 23:58:02
Duration    : 22m 2s
CPU hours   : 2.0
Succeeded   : 33

```

</details>


![image](https://user-images.githubusercontent.com/38183826/126849222-12e88b80-b05d-487a-99ae-1ae1b8ae765d.png)

### Successful run in CloudOS 

**CPUS**: 2
**RAM**:  4 GiB
**Duration**: 23min
**Cost**: $0.06

:link: https://cloudos.lifebit.ai/public/jobs/60fb087495a1d6019a1fb88b


![image](https://user-images.githubusercontent.com/38183826/126831928-76ac5113-84e7-4aab-9832-c4ff8188184c.png)



## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
