### PR TITLE
Adds CI trigger for push to important branches [main, dev]

### DIFF
--- a/.github/workflows/ci_test_with_sqanti.yml
+++ b/.github/workflows/ci_test_with_sqanti.yml
@@ -1,11 +1,13 @@
 name: Testing for Long Reads Proteogenomics with Sqanti
 # This workflow runs the pipeline with the minimal test dataset to check that it completes without any errors
+
+# Push to main or dev branches, or any commit pushed against an open pull request will trigger the CI workflow
 on:
   push:
+    branches: [main, dev]
+  # options for triggers can be found here: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
   pull_request:
-  release:
-    types: [published]
-
+    types: [opened, edited, synchronize, reopened]
 jobs:
   test:
     name: Run workflow tests

--- a/.github/workflows/ci_test_with_sqanti.yml
+++ b/.github/workflows/ci_test_with_sqanti.yml
@@ -1,9 +1,7 @@
 name: Testing for Long Reads Proteogenomics with Sqanti
-# This workflow runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
+# This workflow runs the pipeline with the minimal test dataset to check that it completes without any errors
 on:
   push:
-    branches:
-      - dev
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
Currently it only is triggered on pull request and push to dev, but we would want to see which push commit breaks the pipeline.

<!--
# sheynkman-lab/Long-Read-Proteogenomics pull request

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.
-->

## PR checklist

- Adds more explicit CI triggers, to include missing `push` trigger when the PR is squashed and merged to either `dev` or `main`.




