### PR TITLE
Increases DOI badge size in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This Repository contains the complete software and documentation to execute the Long-Read-Proteogenomics Workflow.
 
+## Digital Object Identifiers
+
 For the Genome Biology Manuscript.
 | DOI    | Description       |
 | ------------- | --------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This Repository contains the complete software and documentation to execute the 
 For the Genome Biology Manuscript.
 | DOI    | Description       |
 | ------------- | --------------------------------------------------------------------------- |
-| [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5920817.svg)](https://doi.org/10.5281/zenodo.5920817) | Contains the version of the repository used for execution and generation of data |
-| [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5703754.svg)](https://doi.org/10.5281/zenodo.5703754) | Contains the input data from Jurkat Samples and Reference data used in execution of the Long-Read-Proteogenomics workflow contained in this repository| 
-| [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5920920.svg)](https://doi.org/10.5281/zenodo.5920920) | Contains the output data from executing the Long-Read-Proteogenomics workflow using the Zenodo version of this repository |
-| [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5920847.svg)](https://doi.org/10.5281/zenodo.5920847) | Contains the version of analysis codes and codes for generating the figures using as input the output data from executing the Long-Read-Proteogenomics Workflow version specified above |
-| [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5234651.svg)](https://doi.org/10.5281/zenodo.5234651) | Contains the Test Data used with the GitHub Actions to ensure changes to this repository still execute and perform correctly |
+| <a href="https://doi.org/10.5281/zenodo.5920817" target="_blank"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.5920817.svg?raw=true" alt="drawing" width="500"/></a> | Contains the version of the repository used for execution and generation of data |
+| <a href="https://doi.org/10.5281/zenodo.5703754" target="_blank"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.5703754.svg?raw=true" alt="drawing" width="500"/></a> | Contains the input data from Jurkat Samples and Reference data used in execution of the Long-Read-Proteogenomics workflow contained in this repository| 
+| <a href="https://doi.org/10.5281/zenodo.5920920" target="_blank"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.5920920.svg?raw=true" alt="drawing" width="500"/></a> | Contains the output data from executing the Long-Read-Proteogenomics workflow using the Zenodo version of this repository |
+|  <a href="https://doi.org/10.5281/zenodo.5920847" target="_blank"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.5920847.svg?raw=true" alt="drawing" width="500"/></a> | Contains the version of analysis codes and codes for generating the figures using as input the output data from executing the Long-Read-Proteogenomics Workflow version specified above |
+|  <a href="https://doi.org/10.5281/zenodo.5234651" target="_blank"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.5234651.svg?raw=true" alt="drawing" width="500"/></a> | Contains the Test Data used with the GitHub Actions to ensure changes to this repository still execute and perform correctly |
 
 | Sequence Read Archive (SRA) Project Reference    | Description       |
 | ------------- | --------------------------------------------------------------------------- |


### PR DESCRIPTION
<!--
# sheynkman-lab/Long-Read-Proteogenomics pull request

Many thanks for contributing to sheynkman-lab/Long-Read-Proteogenomics!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)

 (minor aesthetic change added, does not affect analysis code)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated

## Description

This small PR adds an aesthetic change in the README. It resizes the DOI badges for the datasets in the table.

**Before:**

Link to view file: 
(current `master` branch)
https://github.com/sheynkman-lab/Long-Read-Proteogenomics/blob/6af9cd20d3cebb5ac29ffad5bb5a1842fd7aca63/README.md
![image](https://user-images.githubusercontent.com/38183826/151867237-38063552-28b2-42e7-92b8-ff6d10398423.png)


**After:**

Link to view file: 
(introduced in the branch `increases-doi-badge-size` )
https://github.com/sheynkman-lab/Long-Read-Proteogenomics/blob/increases-doi-badge-size/README.md#digital-object-identifiers

![image](https://user-images.githubusercontent.com/38183826/151867128-a7a0798a-3ab1-4caa-af62-eddeb207ae61.png)
