### PR TITLE
[WIP] Implement easier singularity compatibility

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1293,7 +1293,7 @@ Mass Spec File Conversion
  * by not specifying the output file, the input file is overwritten
 ---------------------------------------------------*/
 process mass_spec_raw_convert{
-
+    containerOptions "--writable-tmpfs"
     publishDir "${params.outdir}/${params.name}/raw_convert/", mode: 'copy'
     when:
       params.mass_spec != false

--- a/setup_docker.sh
+++ b/setup_docker.sh
@@ -1,0 +1,5 @@
+sed -i.bak 's/.\/singularity_images\/pwiz_sandbox/chambm\/pwiz-skyline-i-agree-to-the-vendor-licenses/g' \
+    nextflow.config &&
+    rm nextflow.config.bak
+sed -i.bak 's/singularity.enabled/docker.enabled/g' nextflow.config &&
+    rm nextflow.config.bak

--- a/setup_singularity.sh
+++ b/setup_singularity.sh
@@ -1,0 +1,6 @@
+bash download_pwiz_sandbox.sh
+sed -i.bak 's/chambm\/pwiz-skyline-i-agree-to-the-vendor-licenses/.\/singularity_images\/pwiz_sandbox/g' \
+    nextflow.config &&
+    rm nextflow.config.bak
+sed -i.bak 's/docker.enabled/singularity.enabled/g' nextflow.config &&
+    rm nextflow.config.bak


### PR DESCRIPTION
## Description
Implements methods to make it easier to run the LRP pipeline on singularity via a proteowizard sandbox.

Changes:

1. Enable `--writable-tmpfs` for wine (#165)
2. Use a proteowizard sandbox for running wine on singularity (https://github.com/ProteoWizard/pwiz/issues/2387#issuecomment-1320984700)
3. Implement bash scripts to easily switch between docker and singularity (sandbox isn't actually online yet, we need to add it to Zenodo or similar later on)

Documentation etc will be added once this has been verified to work on other systems/clusters. I have already verified this on two of my systems.

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [] `CHANGELOG.md` is updated
- [] If you've fixed a bug or added code that should be tested, add tests!
- [] Documentation in `docs` is updated

Let me know if you have any feedback, this is still WIP to some extent.